### PR TITLE
Change 'pathtoRegexp' to 'pathToRegexp' in send_sample_request.js

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -56,7 +56,7 @@ define([
       var url = $root.find(".sample-request-url").val();
 
       // Insert url parameter
-      var pattern = pathtoRegexp(url, null);
+      var pattern = pathToRegexp(url, null);
       var matches = pattern.exec(url);
       for (var i = 1; i < matches.length; i++) {
           var key = matches[i].substr(1);


### PR DESCRIPTION
Function 'pathtoRegexp' is undefined in send_sample_request.js. It would appear that the intended function is named, 'pathToRegexp'.